### PR TITLE
Pass description attribute through in regular_service_perimeter module

### DIFF
--- a/modules/regular_service_perimeter/main.tf
+++ b/modules/regular_service_perimeter/main.tf
@@ -20,6 +20,7 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
   perimeter_type = "PERIMETER_TYPE_REGULAR"
   name           = "accessPolicies/${var.policy}/servicePerimeters/${var.perimeter_name}"
   title          = var.perimeter_name
+  description    = var.description
 
   status {
     restricted_services = var.restricted_services


### PR DESCRIPTION
The `regular_service_perimeter` module accepts a `description` variable, but does not pass it through to the underlying [`google_access_context_manager_service_perimeter` resource](https://www.terraform.io/docs/providers/google/r/access_context_manager_service_perimeter.html#description).