### PR TITLE
add regions and require_corp_owned to access level module

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -38,6 +38,7 @@ suites:
           controls:
             - big_query_vpc_positive_test
             - big_query_vpc_negative_test
+            - access_level_regions_test
     provisioner:
       name: terraform
   - name: "simple_example_bridge"

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -31,13 +31,16 @@ You may use the following gcloud commands:
 | perimeter\_name | Perimeter name of the Access Policy.. | string | `"regular_perimeter_1"` | no |
 | policy\_name | The policy's name. | string | n/a | yes |
 | protected\_project\_ids | Project id and number of the project INSIDE the regular service perimeter. This map variable expects an "id" for the project id and "number" key for the project number. | object | n/a | yes |
+| regions | The request must originate from one of the provided countries/regions. Format: A valid ISO 3166-1 alpha-2 code. | list(string) | `<list>` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| access\_level\_name | Access level name of the Access Policy. |
 | dataset\_id | Unique id for the BigQuery dataset being provisioned |
 | dataset\_name | Name of dataset being provisioned |
+| policy\_id | Resource name of the AccessPolicy. |
 | policy\_name | Name of the parent policy |
 | protected\_project\_id | Project id of the project INSIDE the regular service perimeter |
 | table\_id | Unique id for the BigQuery table being provisioned |

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -30,6 +30,7 @@ module "access_level_members" {
   policy      = module.access_context_manager_policy.policy_id
   name        = var.access_level_name
   members     = var.members
+  regions     = var.regions
 }
 
 resource "null_resource" "wait_for_members" {

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -14,9 +14,19 @@
  * limitations under the License.
  */
 
+output "policy_id" {
+  description = "Resource name of the AccessPolicy."
+  value       = module.access_context_manager_policy.name
+}
+
 output "policy_name" {
   description = "Name of the parent policy"
   value       = var.policy_name
+}
+
+output "access_level_name" {
+  description = "Access level name of the Access Policy."
+  value       = var.access_level_name
 }
 
 output "protected_project_id" {

--- a/examples/simple_example/outputs.tf
+++ b/examples/simple_example/outputs.tf
@@ -16,7 +16,7 @@
 
 output "policy_id" {
   description = "Resource name of the AccessPolicy."
-  value       = module.access_context_manager_policy.name
+  value       = module.access_context_manager_policy.policy_id
 }
 
 output "policy_name" {

--- a/examples/simple_example/variables.tf
+++ b/examples/simple_example/variables.tf
@@ -34,6 +34,12 @@ variable "members" {
   type        = list(string)
 }
 
+variable "regions" {
+  description = "The request must originate from one of the provided countries/regions. Format: A valid ISO 3166-1 alpha-2 code."
+  type        = list(string)
+  default     = []
+}
+
 variable "access_level_name" {
   description = "Access level name of the Access Policy."
   type        = string

--- a/modules/access_level/README.md
+++ b/modules/access_level/README.md
@@ -38,6 +38,8 @@ module "access_level_members" {
 | negate | Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields, each field must be false for the Condition overall to be satisfied. | bool | `"false"` | no |
 | os\_type | The operating system type of the device. | string | `"OS_UNSPECIFIED"` | no |
 | policy | Name of the parent policy | string | n/a | yes |
+| regions | Condition - The request must originate from one of the provided countries/regions. Format: A valid ISO 3166-1 alpha-2 code. | list(string) | `<list>` | no |
+| require\_corp\_owned | Condition - Whether the device needs to be corp owned. | bool | `"false"` | no |
 | require\_screen\_lock | Condition - Whether or not screenlock is required for the DevicePolicy to be true. | bool | `"false"` | no |
 | required\_access\_levels | Condition - A list of other access levels defined in the same Policy, referenced by resource name. Referencing an AccessLevel which does not exist is an error. All access levels listed must be granted for the Condition to be true. | list(string) | `<list>` | no |
 

--- a/modules/access_level/main.tf
+++ b/modules/access_level/main.tf
@@ -31,14 +31,16 @@ resource "google_access_context_manager_access_level" "access_level" {
       required_access_levels = var.required_access_levels
       members                = var.members
       negate                 = var.negate
+      regions                = var.regions
 
       dynamic "device_policy" {
-        for_each = var.require_screen_lock || length(var.allowed_encryption_statuses) > 0 || length(var.allowed_device_management_levels) > 0 || var.minimum_version != "" || var.os_type != "OS_UNSPECIFIED" ? [{}] : []
+        for_each = var.require_corp_owned || var.require_screen_lock || length(var.allowed_encryption_statuses) > 0 || length(var.allowed_device_management_levels) > 0 || var.minimum_version != "" || var.os_type != "OS_UNSPECIFIED" ? [{}] : []
 
         content {
           require_screen_lock              = var.require_screen_lock
           allowed_encryption_statuses      = var.allowed_encryption_statuses
           allowed_device_management_levels = var.allowed_device_management_levels
+          require_corp_owned               = var.require_corp_owned
 
           os_constraints {
             minimum_version = var.minimum_version

--- a/modules/access_level/variables.tf
+++ b/modules/access_level/variables.tf
@@ -54,6 +54,12 @@ variable "members" {
   default     = []
 }
 
+variable "regions" {
+  description = "Condition - The request must originate from one of the provided countries/regions. Format: A valid ISO 3166-1 alpha-2 code."
+  type        = list(string)
+  default     = []
+}
+
 variable "negate" {
   description = "Whether to negate the Condition. If true, the Condition becomes a NAND over its non-empty fields, each field must be false for the Condition overall to be satisfied."
   type        = bool
@@ -62,6 +68,12 @@ variable "negate" {
 
 variable "require_screen_lock" {
   description = "Condition - Whether or not screenlock is required for the DevicePolicy to be true."
+  type        = bool
+  default     = false
+}
+
+variable "require_corp_owned" {
+  description = "Condition - Whether the device needs to be corp owned."
   type        = bool
   default     = false
 }

--- a/test/fixtures/shared/outputs.tf
+++ b/test/fixtures/shared/outputs.tf
@@ -18,8 +18,16 @@ output "parent_id" {
   value = var.parent_id
 }
 
+output "policy_id" {
+  value = module.example.policy_id
+}
+
 output "policy_name" {
   value = module.example.policy_name
+}
+
+output "access_level_name" {
+  value = module.example.access_level_name
 }
 
 output "protected_project_id" {

--- a/test/fixtures/simple_example/main.tf
+++ b/test/fixtures/simple_example/main.tf
@@ -24,6 +24,7 @@ module "example" {
   policy_name           = "int_test_vpc_sc_policy_${random_id.random_suffix.hex}"
   protected_project_ids = var.protected_project_ids
   members               = var.members
+  regions               = ["US", "CA"]
   access_level_name     = "vpc_sc_members_test_${random_id.random_suffix.hex}"
   perimeter_name        = "perimeter_vpc_sc_test_${random_id.random_suffix.hex}"
   dataset_id            = "dataset_vpc_sc_test_${random_id.random_suffix.hex}"

--- a/test/integration/simple_example/controls/gcloud.rb
+++ b/test/integration/simple_example/controls/gcloud.rb
@@ -56,9 +56,7 @@ control "access_level_regions_test" do
     describe 'allowed regions' do
       regions_to_allow.each do |region|
         it "#{region} should be allowed" do
-          expect(data['basic']['conditions'][0]['regions']).to include(
-            'regions' => [region]
-          )
+          expect(data['basic']['conditions'][0]['regions']).to include(region)
         end
       end
     end

--- a/test/integration/simple_example/controls/gcloud.rb
+++ b/test/integration/simple_example/controls/gcloud.rb
@@ -56,7 +56,7 @@ control "access_level_regions_test" do
     describe 'allowed regions' do
       regions_to_allow.each do |region|
         it "#{region} should be allowed" do
-          expect(data['basic']['conditions'][0]).to include(
+          expect(data['basic']['conditions'][0]['regions']).to include(
             'regions' => [region]
           )
         end

--- a/test/integration/simple_example/inspec.yml
+++ b/test/integration/simple_example/inspec.yml
@@ -3,6 +3,12 @@ attributes:
   - name: protected_project_id
     required: true
     type: string
+  - name: policy_id
+    required: true
+    type: string
+  - name: access_level_name
+    required: true
+    type: string
   - name: public_project_id
     required: true
     type: string


### PR DESCRIPTION
This PR adds support for: 

* [regions](https://cloud.google.com/access-context-manager/docs/access-level-attributes#regions) attribute
* require_corp_owned in [device policy](https://cloud.google.com/access-context-manager/docs/access-level-attributes#device-policy) attribute 

in the the access level module.