### PR TITLE
Make shared_resources variable a map

### DIFF
--- a/modules/regular_service_perimeter/README.md
+++ b/modules/regular_service_perimeter/README.md
@@ -43,7 +43,7 @@ module "regular_service_perimeter_1" {
 | resources\_dry\_run | (Dry-run) A list of GCP resources that are inside of the service perimeter. Currently only projects are allowed. If set, a dry-run policy will be set. | list(string) | `<list>` | no |
 | restricted\_services | GCP services that are subject to the Service Perimeter restrictions. Must contain a list of services. For example, if storage.googleapis.com is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions. | list(string) | `<list>` | no |
 | restricted\_services\_dry\_run | (Dry-run) GCP services that are subject to the Service Perimeter restrictions. Must contain a list of services. For example, if storage.googleapis.com is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions.  If set, a dry-run policy will be set. | list(string) | `<list>` | no |
-| shared\_resources | A map of lists of resources to share in a Bridge perimeter module. Each list should contain all or a subset of the perimeters resources | object | `<map>` | no |
+| shared\_resources | A map of lists of resources to share in a Bridge perimeter module. Each list should contain all or a subset of the perimeters resources | map(list(string)) | `<map>` | no |
 
 ## Outputs
 

--- a/modules/regular_service_perimeter/variables.tf
+++ b/modules/regular_service_perimeter/variables.tf
@@ -66,6 +66,6 @@ variable "access_levels_dry_run" {
 
 variable "shared_resources" {
   description = "A map of lists of resources to share in a Bridge perimeter module. Each list should contain all or a subset of the perimeters resources"
-  type        = object({ all = list(string) })
+  type        = map(list(string))
   default     = { all = [] }
 }


### PR DESCRIPTION
The original type doesn't match the description. Having it as an `object` means that Terraform discards any keys passed to it that aren't `all`, which doesn't seem desirable.