### PR TITLE
fix: add resource_keys variable to handle dynamic resources

### DIFF
--- a/docs/upgrading_to_v4.0.md
+++ b/docs/upgrading_to_v4.0.md
@@ -16,7 +16,7 @@ However, this change has a few implications:
 If resources are created inside the same configuration as the perimeter, you will received an error that their value cannot be determined until apply:
 ```
 │ Error: Invalid for_each argument
-│ 
+│
 │   on ../../modules/regular_service_perimeter/main.tf line 195, in resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource":
 │  195:   for_each       = local.resources
 │     ├────────────────

--- a/docs/upgrading_to_v4.0.md
+++ b/docs/upgrading_to_v4.0.md
@@ -34,7 +34,7 @@ To work around this, you need to provide a `resource_keys` variable input with k
   ...
 
   resources      = [module.project_two.project_number, module.project_three.project_number]
-+ resource_keys  = ["two", "three"] 
++ resource_keys  = ["two", "three"]
 }
 
 module "bridge" {

--- a/docs/upgrading_to_v4.0.md
+++ b/docs/upgrading_to_v4.0.md
@@ -1,0 +1,92 @@
+# Upgrading to v4.x
+
+The v4.x release is a backwards-incompatible release.
+
+The `resources` inside perimeters have been split into their [own Terraform resource](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/access_context_manager_service_perimeter_resource).
+This allows you to add resources (projects) to the perimeter from *outside* the module.
+
+However, this change has a few implications:
+1. Resources added to the perimeter out-of-band will no longer be removed by Terraform.
+   You will need to develop an alternative system for dealing with these.
+2. The location of resources has moved in the state file.
+3. Because resources are now created using `for_each`, if the underlying project is created in the **same**
+   Terraform configuration as the perimeter, you will need to provide a `resource_keys` variable.
+
+## Dynamic resources
+If resources are created inside the same configuration as the perimeter, you will received an error that their value cannot be determined until apply:
+```
+│ Error: Invalid for_each argument
+│ 
+│   on ../../modules/regular_service_perimeter/main.tf line 195, in resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource":
+│  195:   for_each       = local.resources
+│     ├────────────────
+│     │ local.resources will be known only after apply
+```
+
+To work around this, you need to provide a `resource_keys` variable input with keys for each resource. These keys are only used by Terraform and can be any alphanumeric string.
+
+```diff
+ module "regular_service_perimeter_2" {
+   source  = "terraform-google-modules/vpc-service-controls/google//modules/regular_service_perimeter"
+-  version = "~> 3.0"
++  version = "~> 4.0"
+
+  ...
+
+  resources      = [module.project_two.project_number, module.project_three.project_number]
++ resource_keys  = ["two", "three"] 
+}
+
+module "bridge" {
+   source  = "terraform-google-modules/vpc-service-controls/google//modules/bridge_service_perimeter"
+-  version = "~> 3.0"
++  version = "~> 4.0"
+
+  ...
+
+  resources = concat(
+    module.regular_service_perimeter_1.shared_resources["all"],
+    module.regular_service_perimeter_2.shared_resources["all"],
+  )
++ resource_keys = ["one", "two", "three"]
+}
+```
+
+## State migration
+
+If you run `terraform plan` on an upgraded module, you will notice that Terraform wants to add `service_perimeter` resources.
+
+```
+Terraform will perform the following actions:
+
+  # module.bridge.google_access_context_manager_service_perimeter_resource.service_perimeter_resource["projects/34502780858"] will be created
+  + resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource" {
+      + id             = (known after apply)
+      + perimeter_name = "accessPolicies/209696272439/servicePerimeters/bridge_perimeter_1"
+      + resource       = "projects/34502780858"
+    }
+
+  # module.bridge.google_access_context_manager_service_perimeter_resource.service_perimeter_resource["projects/843696391937"] will be created
+  + resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource" {
+      + id             = (known after apply)
+      + perimeter_name = "accessPolicies/209696272439/servicePerimeters/bridge_perimeter_1"
+      + resource       = "projects/843696391937"
+    }
+
+  # module.regular_service_perimeter_1.google_access_context_manager_service_perimeter_resource.service_perimeter_resource["34502780858"] will be created
+  + resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource" {
+      + id             = (known after apply)
+      + perimeter_name = "accessPolicies/209696272439/servicePerimeters/regular_perimeter_1"
+      + resource       = "projects/34502780858"
+    }
+
+Plan: 3 to add, 0 to change, 0 to destroy.
+```
+
+For each resource, you will need to import it into the Terraform config:
+
+```
+terraform import 'module.bridge.google_access_context_manager_service_perimeter_resource.service_perimeter_resource["one"]' 'accessPolicies/209696272439/servicePerimeters/bridge_perimeter_1/projects/34502780858'
+terraform import 'module.bridge.google_access_context_manager_service_perimeter_resource.service_perimeter_resource["two"]' 'accessPolicies/209696272439/servicePerimeters/bridge_perimeter_1/projects/843696391937'
+terraform import 'module.regular_service_perimeter_1.google_access_context_manager_service_perimeter_resource.service_perimeter_resource["34502780858"]' 'accessPolicies/209696272439/servicePerimeters/regular_perimeter_1/projects/34502780858'
+```

--- a/examples/simple_example_dynamic/README.md
+++ b/examples/simple_example_dynamic/README.md
@@ -15,7 +15,7 @@ This example illustrates how to use the module to create two perimeters, with pr
 
 | Name | Description |
 |------|-------------|
-| policy\_name | n/a |
+| policy\_id | The ID of the created policy |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/simple_example_dynamic/README.md
+++ b/examples/simple_example_dynamic/README.md
@@ -1,0 +1,27 @@
+# Simple Example Dynamic
+
+This example illustrates how to use the module to create two perimeters, with projects inside of them, and a bridge between the two.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent. | `string` | n/a | yes |
+| policy\_name | The policy's name. | `string` | n/a | yes |
+| protected\_project\_ids | Project id and number of the project INSIDE the regular service perimeter. This map variable expects an "id" for the project id and "number" key for the project number. | `object({ id = string, number = number })` | n/a | yes |
+| public\_project\_ids | Project id and number of the project OUTSIDE of the regular service perimeter. This variable is only necessary for running integration tests. This map variable expects an "id" for the project id and "number" key for the project number. | `object({ id = string, number = number })` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| policy\_name | n/a |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/simple_example_dynamic/README.md
+++ b/examples/simple_example_dynamic/README.md
@@ -7,10 +7,9 @@ This example illustrates how to use the module to create two perimeters, with pr
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| billing\_account | The billing account to use for creating projects | `string` | n/a | yes |
 | parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent. | `string` | n/a | yes |
-| policy\_name | The policy's name. | `string` | n/a | yes |
-| protected\_project\_ids | Project id and number of the project INSIDE the regular service perimeter. This map variable expects an "id" for the project id and "number" key for the project number. | `object({ id = string, number = number })` | n/a | yes |
-| public\_project\_ids | Project id and number of the project OUTSIDE of the regular service perimeter. This variable is only necessary for running integration tests. This map variable expects an "id" for the project id and "number" key for the project number. | `object({ id = string, number = number })` | n/a | yes |
+| policy\_name | The policy's name. | `string` | `"vpc-sc"` | no |
 
 ## Outputs
 

--- a/examples/simple_example_dynamic/main.tf
+++ b/examples/simple_example_dynamic/main.tf
@@ -26,11 +26,13 @@ module "bridge" {
   perimeter_name = "bridge_perimeter_1"
   description    = "Some description"
 
-  resources = concat(
-    module.regular_service_perimeter_1.shared_resources["all"],
-    module.regular_service_perimeter_2.shared_resources["all"],
-  )
+  resources     = [module.project_one.project_number, module.project_two.project_number, module.project_three.project_number]
   resource_keys = ["one", "two", "three"]
+
+  depends_on = [
+    module.regular_service_perimeter_1,
+    module.regular_service_perimeter_2
+  ]
 }
 
 module "regular_service_perimeter_1" {

--- a/examples/simple_example_dynamic/main.tf
+++ b/examples/simple_example_dynamic/main.tf
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "access_context_manager_policy" {
+  source      = "../.."
+  parent_id   = var.parent_id
+  policy_name = var.policy_name
+}
+
+module "bridge" {
+  source         = "../../modules/bridge_service_perimeter"
+  policy         = module.access_context_manager_policy.policy_id
+  perimeter_name = "bridge_perimeter_1"
+  description    = "Some description"
+
+  resources = concat(
+    module.regular_service_perimeter_1.shared_resources["all"],
+    module.regular_service_perimeter_2.shared_resources["all"],
+  )
+  resource_keys = ["one", "two", "three"]
+}
+
+module "regular_service_perimeter_1" {
+  source         = "../../modules/regular_service_perimeter"
+  policy         = module.access_context_manager_policy.policy_id
+  perimeter_name = "regular_perimeter_1"
+  description    = "Some description"
+  resources      = [module.project_one.project_number]
+
+  restricted_services = ["bigquery.googleapis.com", "storage.googleapis.com"]
+
+  shared_resources = {
+    all = [module.project_one.project_number]
+  }
+}
+
+module "regular_service_perimeter_2" {
+  source         = "../../modules/regular_service_perimeter"
+  policy         = module.access_context_manager_policy.policy_id
+  perimeter_name = "regular_perimeter_2"
+  description    = "Some description"
+  resources      = [module.project_two.project_number, module.project_three.project_number]
+  resource_keys  = ["two", "three"]
+
+  restricted_services = ["storage.googleapis.com"]
+
+  shared_resources = {
+    all = [module.project_two.project_number, module.project_three.project_number]
+  }
+}

--- a/examples/simple_example_dynamic/outputs.tf
+++ b/examples/simple_example_dynamic/outputs.tf
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
-output "policy_name" {
-  value = var.policy_name
+output "policy_id" {
+  description = "The ID of the created policy"
+  value       = module.access_context_manager_policy.policy_id
 }

--- a/examples/simple_example_dynamic/outputs.tf
+++ b/examples/simple_example_dynamic/outputs.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "policy_name" {
+  value = var.policy_name
+}

--- a/examples/simple_example_dynamic/projects.tf
+++ b/examples/simple_example_dynamic/projects.tf
@@ -18,28 +18,28 @@ module "project_one" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"
 
-  name                 = "vpcsc-test-one"
-  random_project_id    = true
-  org_id               = var.parent_id
-  billing_account      = var.billing_account
+  name              = "vpcsc-test-one"
+  random_project_id = true
+  org_id            = var.parent_id
+  billing_account   = var.billing_account
 }
 
 module "project_two" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"
 
-  name                 = "vpcsc-test-two"
-  random_project_id    = true
-  org_id               = var.parent_id
-  billing_account      = var.billing_account
+  name              = "vpcsc-test-two"
+  random_project_id = true
+  org_id            = var.parent_id
+  billing_account   = var.billing_account
 }
 
 module "project_three" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 10.0"
 
-  name                 = "vpcsc-test-two"
-  random_project_id    = true
-  org_id               = var.parent_id
-  billing_account      = var.billing_account
+  name              = "vpcsc-test-two"
+  random_project_id = true
+  org_id            = var.parent_id
+  billing_account   = var.billing_account
 }

--- a/examples/simple_example_dynamic/projects.tf
+++ b/examples/simple_example_dynamic/projects.tf
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "project_one" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 10.0"
+
+  name                 = "vpcsc-test-one"
+  random_project_id    = true
+  org_id               = var.parent_id
+  billing_account      = var.billing_account
+}
+
+module "project_two" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 10.0"
+
+  name                 = "vpcsc-test-two"
+  random_project_id    = true
+  org_id               = var.parent_id
+  billing_account      = var.billing_account
+}
+
+module "project_three" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 10.0"
+
+  name                 = "vpcsc-test-two"
+  random_project_id    = true
+  org_id               = var.parent_id
+  billing_account      = var.billing_account
+}

--- a/examples/simple_example_dynamic/variables.tf
+++ b/examples/simple_example_dynamic/variables.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "parent_id" {
+  description = "The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent."
+  type        = string
+}
+
+variable "policy_name" {
+  description = "The policy's name."
+  type        = string
+  default     = "vpc-sc"
+}
+
+variable "billing_account" {
+  description = "The billing account to use for creating projects"
+  type        = string
+}

--- a/examples/simple_example_dynamic/versions.tf
+++ b/examples/simple_example_dynamic/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/examples/simple_example_dynamic/versions.tf
+++ b/examples/simple_example_dynamic/versions.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/bridge_service_perimeter/README.md
+++ b/modules/bridge_service_perimeter/README.md
@@ -63,6 +63,7 @@ module "regular_service_perimeter_2" {
 | description | Description of the bridge perimeter | `string` | `""` | no |
 | perimeter\_name | Name of the perimeter. Should be one unified string. Must only be letters, numbers and underscores | `string` | n/a | yes |
 | policy | Name of the parent policy | `string` | n/a | yes |
+| resource\_keys | A list of keys to use for the Terraform state. The order should correspond to var.resources and the keys must not be dynamically computed. If `null`, var.resources will be used as keys. | `list(string)` | `null` | no |
 | resources | A list of GCP resources that are inside of the service perimeter. Currently only projects are allowed. | `list(string)` | n/a | yes |
 
 ## Outputs

--- a/modules/bridge_service_perimeter/main.tf
+++ b/modules/bridge_service_perimeter/main.tf
@@ -29,7 +29,7 @@ resource "google_access_context_manager_service_perimeter" "bridge_service_perim
 locals {
   resource_keys = var.resource_keys != null ? var.resource_keys : var.resources
   resources = {
-    for rk in local.resource_keys:
+    for rk in local.resource_keys :
     rk => var.resources[index(local.resource_keys, rk)]
   }
 }

--- a/modules/bridge_service_perimeter/main.tf
+++ b/modules/bridge_service_perimeter/main.tf
@@ -26,9 +26,16 @@ resource "google_access_context_manager_service_perimeter" "bridge_service_perim
   }
 }
 
+locals {
+  resource_keys = var.resource_keys != null ? var.resource_keys : var.resources
+  resources = {
+    for rk in local.resource_keys:
+    rk => var.resources[index(local.resource_keys, rk)]
+  }
+}
 
 resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource" {
-  for_each       = toset(formatlist("projects/%s", var.resources))
+  for_each       = local.resources
   perimeter_name = google_access_context_manager_service_perimeter.bridge_service_perimeter.name
-  resource       = each.key
+  resource       = "projects/${each.value}"
 }

--- a/modules/bridge_service_perimeter/variables.tf
+++ b/modules/bridge_service_perimeter/variables.tf
@@ -34,3 +34,9 @@ variable "resources" {
   description = "A list of GCP resources that are inside of the service perimeter. Currently only projects are allowed."
   type        = list(string)
 }
+
+variable "resource_keys" {
+  description = "A list of keys to use for the Terraform state. The order should correspond to var.resources and the keys must not be dynamically computed. If `null`, var.resources will be used as keys."
+  type        = list(string)
+  default     = null
+}

--- a/modules/regular_service_perimeter/README.md
+++ b/modules/regular_service_perimeter/README.md
@@ -104,6 +104,7 @@ module "regular_service_perimeter_1" {
 | ingress\_policies\_dry\_run | A list of all [ingress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#ingress-rules-reference), each list object has a `from` and `to` value that describes ingress\_from and ingress\_to. | <pre>list(object({<br>    from = any<br>    to   = any<br>  }))</pre> | `[]` | no |
 | perimeter\_name | Name of the perimeter. Should be one unified string. Must only be letters, numbers and underscores | `any` | n/a | yes |
 | policy | Name of the parent policy | `string` | n/a | yes |
+| resource\_keys | A list of keys to use for the Terraform state. The order should correspond to var.resources and the keys must not be dynamically computed. If `null`, var.resources will be used as keys. | `list(string)` | `null` | no |
 | resources | A list of GCP resources that are inside of the service perimeter. Currently only projects are allowed. | `list(string)` | `[]` | no |
 | resources\_dry\_run | (Dry-run) A list of GCP resources that are inside of the service perimeter. Currently only projects are allowed. If set, a dry-run policy will be set. | `list(string)` | `[]` | no |
 | restricted\_services | GCP services that are subject to the Service Perimeter restrictions. Must contain a list of services. For example, if storage.googleapis.com is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions. | `list(string)` | `[]` | no |

--- a/modules/regular_service_perimeter/main.tf
+++ b/modules/regular_service_perimeter/main.tf
@@ -186,7 +186,7 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
 locals {
   resource_keys = var.resource_keys != null ? var.resource_keys : var.resources
   resources = {
-    for rk in local.resource_keys:
+    for rk in local.resource_keys :
     rk => var.resources[index(local.resource_keys, rk)]
   }
 }

--- a/modules/regular_service_perimeter/main.tf
+++ b/modules/regular_service_perimeter/main.tf
@@ -183,9 +183,16 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
   }
 }
 
+locals {
+  resource_keys = var.resource_keys != null ? var.resource_keys : var.resources
+  resources = {
+    for rk in local.resource_keys:
+    rk => var.resources[index(local.resource_keys, rk)]
+  }
+}
 
 resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource" {
-  for_each       = toset(formatlist("projects/%s", var.resources))
+  for_each       = local.resources
   perimeter_name = google_access_context_manager_service_perimeter.regular_service_perimeter.name
-  resource       = each.key
+  resource       = "projects/${each.value}"
 }

--- a/modules/regular_service_perimeter/variables.tf
+++ b/modules/regular_service_perimeter/variables.tf
@@ -40,6 +40,12 @@ variable "resources" {
   default     = []
 }
 
+variable "resource_keys" {
+  description = "A list of keys to use for the Terraform state. The order should correspond to var.resources and the keys must not be dynamically computed. If `null`, var.resources will be used as keys."
+  type        = list(string)
+  default     = null
+}
+
 variable "access_levels" {
   description = "A list of AccessLevel resource names that allow resources within the ServicePerimeter to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel is a syntax error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via GCP calls with request origins within the perimeter. Example: 'accessPolicies/MY_POLICY/accessLevels/MY_LEVEL'. For Service Perimeter Bridge, must be empty."
   type        = list(string)


### PR DESCRIPTION
Now that resources are created using `for_each`, if the resources are created in the same `apply` they need to have a (separate) key.

Fixes #76.