### PR TITLE
Fix dry-run egress ingress operations

### DIFF
--- a/modules/regular_service_perimeter/main.tf
+++ b/modules/regular_service_perimeter/main.tf
@@ -134,11 +134,11 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
               content {
                 service_name = operations.key
                 dynamic "method_selectors" {
-                  for_each = merge(
+                  for_each = operations.key != "*" ? merge(
                     { for k, v in lookup(operations.value, "methods", {}) : v => "method" },
-                  { for k, v in lookup(operations.value, "permissions", {}) : v => "permission" })
+                  { for k, v in lookup(operations.value, "permissions", {}) : v => "permission" }) : {}
                   content {
-                    method     = method_selectors.value == "method" ? method_selectors.key : ""
+                    method     = method_selectors.value == "method" ? method_selectors.key : null
                     permission = method_selectors.value == "permission" ? method_selectors.key : ""
                   }
                 }
@@ -161,9 +161,9 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
               content {
                 service_name = operations.key
                 dynamic "method_selectors" {
-                  for_each = merge(
+                  for_each = operations.key != "*" ? merge(
                     { for k, v in lookup(operations.value, "methods", {}) : v => "method" },
-                  { for k, v in lookup(operations.value, "permissions", {}) : v => "permission" })
+                  { for k, v in lookup(operations.value, "permissions", {}) : v => "permission" }) : {}
                   content {
                     method     = method_selectors.value == "method" ? method_selectors.key : ""
                     permission = method_selectors.value == "permission" ? method_selectors.key : ""


### PR DESCRIPTION
This change is to fix the dynamic operations on ingress and egress policies in dry-run mode, these are currently failing
The change itself is just update "spec" to match "status" implementation that is properly working