### PR TITLE
Adding Scopes to Access Policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
-### [4.0.1](https://github.com/terraform-google-modules/terraform-google-vpc-service-controls/compare/v4.0.0...v4.0.1) (2022-03-17)
+### [4.0.2](https://github.com/terraform-google-modules/terraform-google-vpc-service-controls/issues/86) (2022-05-28)
 
+### Features
+
+* Added Scopes Argument for Access Policies ([#86](https://github.com/terraform-google-modules/terraform-google-vpc-service-controls/issues/86))
+
+### [4.0.1](https://github.com/terraform-google-modules/terraform-google-vpc-service-controls/compare/v4.0.0...v4.0.1) (2022-03-17)
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can add a delay using terraform's [`null_resource`](https://www.terraform.io
 |------|-------------|------|---------|:--------:|
 | parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent. | `string` | n/a | yes |
 | policy\_name | The policy's name. | `string` | n/a | yes |
+| scopes | Folder or project that the Access Policy applies to. | `list(string)` | `""` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can add a delay using terraform's [`null_resource`](https://www.terraform.io
 |------|-------------|------|---------|:--------:|
 | parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent. | `string` | n/a | yes |
 | policy\_name | The policy's name. | `string` | n/a | yes |
-| scopes | Folder or project that the Access Policy applies to. | `list(string)` | `""` | no |
+| scopes | Folder or project that the Access Policy applies to. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 
 ## Outputs
 

--- a/examples/simple_example_bridge/README.md
+++ b/examples/simple_example_bridge/README.md
@@ -23,6 +23,7 @@ You may use the following gcloud commands:
 | policy\_name | The policy's name. | `string` | n/a | yes |
 | protected\_project\_ids | Project id and number of the project INSIDE the regular service perimeter. This map variable expects an "id" for the project id and "number" key for the project number. | `object({ id = string, number = number })` | n/a | yes |
 | public\_project\_ids | Project id and number of the project OUTSIDE of the regular service perimeter. This variable is only necessary for running integration tests. This map variable expects an "id" for the project id and "number" key for the project number. | `object({ id = string, number = number })` | n/a | yes |
+| scopes | Folder or project that the Access Policy applies to. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 
 ## Outputs
 

--- a/examples/simple_example_bridge/main.tf
+++ b/examples/simple_example_bridge/main.tf
@@ -18,6 +18,7 @@ module "access_context_manager_policy" {
   source      = "../.."
   parent_id   = var.parent_id
   policy_name = var.policy_name
+  scopes      = var.scopes
 }
 
 module "bridge_service_perimeter_1" {

--- a/examples/simple_example_bridge/variables.tf
+++ b/examples/simple_example_bridge/variables.tf
@@ -33,3 +33,9 @@ variable "public_project_ids" {
   description = "Project id and number of the project OUTSIDE of the regular service perimeter. This variable is only necessary for running integration tests. This map variable expects an \"id\" for the project id and \"number\" key for the project number."
   type        = object({ id = string, number = number })
 }
+
+variable "scopes" {
+  description = "Folder or project that the Access Policy applies to."
+  type        = list(string)
+  default     = [""]
+}

--- a/examples/simple_example_dynamic/README.md
+++ b/examples/simple_example_dynamic/README.md
@@ -10,7 +10,6 @@ This example illustrates how to use the module to create two perimeters, with pr
 | billing\_account | The billing account to use for creating projects | `string` | n/a | yes |
 | parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent. | `string` | n/a | yes |
 | policy\_name | The policy's name. | `string` | `"vpc-sc"` | no |
-| scopes | Folder or project that the Access Policy applies to. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 
 ## Outputs
 

--- a/examples/simple_example_dynamic/README.md
+++ b/examples/simple_example_dynamic/README.md
@@ -10,6 +10,7 @@ This example illustrates how to use the module to create two perimeters, with pr
 | billing\_account | The billing account to use for creating projects | `string` | n/a | yes |
 | parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent. | `string` | n/a | yes |
 | policy\_name | The policy's name. | `string` | `"vpc-sc"` | no |
+| scopes | Folder or project that the Access Policy applies to. | `list(string)` | <pre>[<br>  ""<br>]</pre> | no |
 
 ## Outputs
 

--- a/examples/simple_example_dynamic/main.tf
+++ b/examples/simple_example_dynamic/main.tf
@@ -18,7 +18,7 @@ module "access_context_manager_policy" {
   source      = "../.."
   parent_id   = var.parent_id
   policy_name = var.policy_name
-  scopes = var.scopes
+  scopes      = var.scopes
 }
 
 module "bridge" {

--- a/examples/simple_example_dynamic/main.tf
+++ b/examples/simple_example_dynamic/main.tf
@@ -18,7 +18,6 @@ module "access_context_manager_policy" {
   source      = "../.."
   parent_id   = var.parent_id
   policy_name = var.policy_name
-  scopes      = var.scopes
 }
 
 module "bridge" {

--- a/examples/simple_example_dynamic/main.tf
+++ b/examples/simple_example_dynamic/main.tf
@@ -18,6 +18,7 @@ module "access_context_manager_policy" {
   source      = "../.."
   parent_id   = var.parent_id
   policy_name = var.policy_name
+  scopes = var.scopes
 }
 
 module "bridge" {

--- a/examples/simple_example_dynamic/variables.tf
+++ b/examples/simple_example_dynamic/variables.tf
@@ -29,9 +29,3 @@ variable "billing_account" {
   description = "The billing account to use for creating projects"
   type        = string
 }
-
-variable "scopes" {
-  description = "Folder or project that the Access Policy applies to."
-  type        = list(string)
-  default     = [""]
-}

--- a/examples/simple_example_dynamic/variables.tf
+++ b/examples/simple_example_dynamic/variables.tf
@@ -29,3 +29,9 @@ variable "billing_account" {
   description = "The billing account to use for creating projects"
   type        = string
 }
+
+variable "scopes" {
+  description = "Folder or project that the Access Policy applies to."
+  type        = list(string)
+  default     = [""]
+}

--- a/examples/simple_example_policy_scopes/README.md
+++ b/examples/simple_example_policy_scopes/README.md
@@ -1,0 +1,53 @@
+# Simple Example Policy Scopes
+
+This example illustrates how to use the `vpc-service-controls` module to configure an org policy, an access level, a regular perimeter and a BigQuery resource inside the regular perimeter. The org policy will live inside a folder rather than the organization.
+
+# Requirements
+
+1. Make sure you've gone through the root [Requirement Section](../../README.md#requirements) on any project in your organization.
+2. If you need to run integration tests for this example, select a second project in your organization. The project you already configured will be referred as the protected project that will be inside of the regular service perimeter. The second project will be the public project, which will be outside of the regular service perimeter.
+3. Grant the service account the following permissions on the protected project:
+ - roles/bigquery.dataOwner
+ - roles/bigquery.jobUser
+
+You may use the following gcloud commands:
+   `gcloud projects add-iam-policy-binding <project-id> --member=serviceAccount:<service-account-email> --role=roles/bigquery.jobUser`
+   `gcloud projects add-iam-policy-binding <project-id> --member=serviceAccount:<service-account-email> --role=roles/bigquery.dataOwner`
+
+4. Enable BigQuery API on the protected project.
+5. If you want to run the integration tests for this example, repeat step #3 and #4 on the public project.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| access\_level\_name | Access level name of the Access Policy. | `string` | `"terraform_members"` | no |
+| dataset\_id | Unique dataset ID/name that will be created. | `string` | `"sample_dataset"` | no |
+| folder\_name | Unique folder name that will be created. | `string` | `"sample_folder"` | no |
+| members | An allowed list of members (users, service accounts). The signed-in identity originating the request must be a part of one of the provided members. If not specified, a request may come from any user (logged in/not logged in, etc.). Formats: user:{emailid}, serviceAccount:{emailid} | `list(string)` | n/a | yes |
+| parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. Can be a folder or an organization; in this case it is an org. | `string` | n/a | yes |
+| perimeter\_name | Perimeter name of the Access Policy.. | `string` | `"regular_perimeter_1"` | no |
+| policy\_name | The policy's name. | `string` | n/a | yes |
+| protected\_project\_ids | Project id and number of the project INSIDE the regular service perimeter. This map variable expects an "id" for the project id and "number" key for the project number. | `object({ id = string, number = number })` | n/a | yes |
+| regions | The request must originate from one of the provided countries/regions. Format: A valid ISO 3166-1 alpha-2 code. | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| access\_level\_name | Access level name of the Access Policy. |
+| dataset\_id | Unique id for the BigQuery dataset being provisioned |
+| dataset\_name | Name of dataset being provisioned |
+| policy\_id | Resource name of the AccessPolicy. |
+| policy\_name | Name of the parent policy |
+| protected\_project\_id | Project id of the project INSIDE the regular service perimeter |
+| table\_id | Unique id for the BigQuery table being provisioned |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+To provision this example, run the following from within this directory:
+- `terraform init` to get the plugins
+- `terraform plan` to see the infrastructure plan
+- `terraform apply` to apply the infrastructure build
+- `terraform destroy` to destroy the built infrastructure

--- a/examples/simple_example_policy_scopes/main.tf
+++ b/examples/simple_example_policy_scopes/main.tf
@@ -1,0 +1,95 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# Top-level folder under an organization.
+resource "google_folder" "folder" {
+  display_name = var.folder_name
+  parent       = var.parent_id
+}
+
+module "access_context_manager_policy" {
+  source      = "../.."
+  parent_id   = var.parent_id
+  policy_name = var.policy_name
+  scopes      = [google_folder.folder.name]
+}
+
+module "access_level_members" {
+  source      = "../../modules/access_level"
+  description = "Simple Example Access Level"
+  policy      = module.access_context_manager_policy.policy_id
+  name        = var.access_level_name
+  members     = var.members
+  regions     = var.regions
+}
+
+resource "null_resource" "wait_for_members" {
+  provisioner "local-exec" {
+    command = "sleep 60"
+  }
+
+  depends_on = [module.access_level_members]
+}
+
+module "regular_service_perimeter_1" {
+  source         = "../../modules/regular_service_perimeter"
+  policy         = module.access_context_manager_policy.policy_id
+  perimeter_name = var.perimeter_name
+
+  description = "Perimeter shielding bigquery project ${null_resource.wait_for_members.id}"
+  resources   = [var.protected_project_ids["number"]]
+
+  access_levels       = [module.access_level_members.name]
+  restricted_services = ["bigquery.googleapis.com", "storage.googleapis.com"]
+
+  shared_resources = {
+    all = [var.protected_project_ids["number"]]
+  }
+}
+
+module "bigquery" {
+  source                      = "terraform-google-modules/bigquery/google"
+  version                     = "5.3.0"
+  dataset_id                  = var.dataset_id
+  dataset_name                = var.dataset_id
+  description                 = "Dataset with a single table with one field"
+  default_table_expiration_ms = "3600000"
+  project_id                  = var.protected_project_ids["id"]
+  location                    = "US"
+  access                      = []
+  deletion_protection         = false
+
+  tables = [
+    {
+      table_id = "example_table",
+      schema   = file("sample_bq_schema.json")
+      time_partitioning = {
+        type                     = "DAY",
+        field                    = null,
+        require_partition_filter = false,
+        expiration_ms            = null,
+      },
+      range_partitioning = null,
+      expiration_time    = null,
+      clustering         = [],
+      labels = {
+        env      = "dev"
+        billable = "true"
+        owner    = "joedoe"
+      },
+    }
+  ]
+}

--- a/examples/simple_example_policy_scopes/outputs.tf
+++ b/examples/simple_example_policy_scopes/outputs.tf
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "policy_id" {
+  description = "Resource name of the AccessPolicy."
+  value       = module.access_context_manager_policy.policy_id
+}
+
+output "policy_name" {
+  description = "Name of the parent policy"
+  value       = var.policy_name
+}
+
+output "access_level_name" {
+  description = "Access level name of the Access Policy."
+  value       = var.access_level_name
+}
+
+output "protected_project_id" {
+  description = "Project id of the project INSIDE the regular service perimeter"
+  value       = var.protected_project_ids["id"]
+}
+
+output "dataset_id" {
+  description = "Unique id for the BigQuery dataset being provisioned"
+  value       = module.bigquery.bigquery_dataset.dataset_id
+}
+
+output "table_id" {
+  description = "Unique id for the BigQuery table being provisioned"
+  value       = module.bigquery.table_ids
+}
+
+output "dataset_name" {
+  description = "Name of dataset being provisioned"
+  value       = module.bigquery.bigquery_dataset.dataset_id
+}

--- a/examples/simple_example_policy_scopes/sample_bq_schema.json
+++ b/examples/simple_example_policy_scopes/sample_bq_schema.json
@@ -1,0 +1,9 @@
+[
+    {
+      "description": "Example Field",
+      "mode": "NULLABLE",
+      "name": "name",
+      "type": "STRING"
+    }
+]
+

--- a/examples/simple_example_policy_scopes/variables.tf
+++ b/examples/simple_example_policy_scopes/variables.tf
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "parent_id" {
+  description = "The parent of this AccessPolicy in the Cloud Resource Hierarchy. Can be a folder or an organization; in this case it is an org."
+  type        = string
+}
+
+variable "policy_name" {
+  description = "The policy's name."
+  type        = string
+}
+
+variable "protected_project_ids" {
+  description = "Project id and number of the project INSIDE the regular service perimeter. This map variable expects an \"id\" for the project id and \"number\" key for the project number."
+  type        = object({ id = string, number = number })
+}
+
+variable "members" {
+  description = "An allowed list of members (users, service accounts). The signed-in identity originating the request must be a part of one of the provided members. If not specified, a request may come from any user (logged in/not logged in, etc.). Formats: user:{emailid}, serviceAccount:{emailid}"
+  type        = list(string)
+}
+
+variable "regions" {
+  description = "The request must originate from one of the provided countries/regions. Format: A valid ISO 3166-1 alpha-2 code."
+  type        = list(string)
+  default     = []
+}
+
+variable "access_level_name" {
+  description = "Access level name of the Access Policy."
+  type        = string
+  default     = "terraform_members"
+}
+
+variable "perimeter_name" {
+  description = "Perimeter name of the Access Policy.."
+  type        = string
+  default     = "regular_perimeter_1"
+}
+variable "dataset_id" {
+  description = "Unique dataset ID/name that will be created."
+  type        = string
+  default     = "sample_dataset"
+}
+
+variable "folder_name" {
+  description = "Unique folder name that will be created."
+  type        = string
+  default     = "sample_folder"
+}

--- a/examples/simple_example_policy_scopes/versions.tf
+++ b/examples/simple_example_policy_scopes/versions.tf
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-variable "parent_id" {
-  description = "The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent."
-  type        = string
-}
-
-variable "policy_name" {
-  description = "The policy's name."
-  type        = string
-}
-
-variable "scopes" {
-  description = "Folder or project that the Access Policy applies to."
-  type        = list(string)
-  default = [""]
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+    null = {
+      source = "hashicorp/null"
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -18,4 +18,5 @@ resource "google_access_context_manager_access_policy" "access_policy" {
   provider = google
   parent   = "organizations/${var.parent_id}"
   title    = var.policy_name
+  scopes   = var.scopes
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,3 +23,8 @@ variable "policy_name" {
   description = "The policy's name."
   type        = string
 }
+
+variable "scopes" {
+  description = "Folder or project on which this policy is applicable."
+  type        = list(string)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -27,5 +27,5 @@ variable "policy_name" {
 variable "scopes" {
   description = "Folder or project that the Access Policy applies to."
   type        = list(string)
-  default = [""]
+  default     = [""]
 }


### PR DESCRIPTION
My company is pretty big on VPCSC and we noticed that Access Policies gained a new option, Scopes. Scopes allow Access Policies to be set for Folders and Projects instead of just the organization. Along with this addition, organizations can now have multiple Access Policies per organization. For some of our more complex customers, this allows us to reduce the amount of orgs they need.

This is my first PR for the terraform-google-modules org and first PR for Open Source projects. 

I have also included an example for this PR and this should resolve feature request #86 .