### PR TITLE
Removed google_access_context_manager_service_perimeter_resource terr…

### DIFF
--- a/modules/regular_service_perimeter/main.tf
+++ b/modules/regular_service_perimeter/main.tf
@@ -32,6 +32,7 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
       "accessPolicies/${var.policy}/accessLevels/%s",
       var.access_levels
     )
+    resources = formatlist("projects/%s", var.resources)
 
     dynamic "ingress_policies" {
       for_each = var.ingress_policies
@@ -205,10 +206,4 @@ locals {
     for rk in local.resource_keys :
     rk => var.resources[index(local.resource_keys, rk)]
   }
-}
-
-resource "google_access_context_manager_service_perimeter_resource" "service_perimeter_resource" {
-  for_each       = local.resources
-  perimeter_name = google_access_context_manager_service_perimeter.regular_service_perimeter.name
-  resource       = "projects/${each.value}"
 }

--- a/modules/regular_service_perimeter/outputs.tf
+++ b/modules/regular_service_perimeter/outputs.tf
@@ -18,8 +18,7 @@ output "shared_resources" {
   description = "A map of lists of resources to share in a Bridge perimeter module. Each list should contain all or a subset of the perimeters resources"
   value       = var.shared_resources
   depends_on = [
-    google_access_context_manager_service_perimeter.regular_service_perimeter,
-    google_access_context_manager_service_perimeter_resource.service_perimeter_resource
+    google_access_context_manager_service_perimeter.regular_service_perimeter
   ]
 }
 
@@ -27,8 +26,7 @@ output "resources" {
   description = "A list of GCP resources that are inside of the service perimeter. Currently only projects are allowed."
   value       = var.resources
   depends_on = [
-    google_access_context_manager_service_perimeter.regular_service_perimeter,
-    google_access_context_manager_service_perimeter_resource.service_perimeter_resource
+    google_access_context_manager_service_perimeter.regular_service_perimeter
   ]
 }
 
@@ -36,7 +34,6 @@ output "perimeter_name" {
   description = "The perimeter's name."
   value       = var.perimeter_name
   depends_on = [
-    google_access_context_manager_service_perimeter.regular_service_perimeter,
-    google_access_context_manager_service_perimeter_resource.service_perimeter_resource
+    google_access_context_manager_service_perimeter.regular_service_perimeter
   ]
 }


### PR DESCRIPTION
Removed google_access_context_manager_service_perimeter_resource terraform resource and move resource list directly into google_access_context_manager_service_perimeter. 
In dry run mode module works but in standard mode doesn't work. There is an error "Error creating ServicePerimeter: googleapi: Error 400: Invalid Directional Policies set in Perimeter 
'accessPolicies/<access_policy_number>/servicePerimeters/xxx': Error in IngressTo: 'projects/<project_number>' 
is defined in `IngressTo.resources`, but it is not present in `ServicePerimeterConfig.resources`. 
Only resources protected by this Service Perimeter can be put in IngressTo.resources." This is caused because ingress rule needs resources list (for example project number) during creation regular service perimeter. I've moved list and deleted reference to google_access_context_manager_service_perimeter_resource in output file. 