### PR TITLE
Fix: Add depends_on in ingress policies resources

### DIFF
--- a/modules/regular_service_perimeter/vpc-sc-policies.tf
+++ b/modules/regular_service_perimeter/vpc-sc-policies.tf
@@ -90,6 +90,8 @@ resource "google_access_context_manager_service_perimeter_ingress_policy" "ingre
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = [google_access_context_manager_service_perimeter_resource.service_perimeter_resource]
 }
 
 resource "google_access_context_manager_service_perimeter_egress_policy" "egress_policies" {
@@ -184,6 +186,8 @@ resource "google_access_context_manager_service_perimeter_dry_run_ingress_policy
   lifecycle {
     create_before_destroy = true
   }
+
+  depends_on = [google_access_context_manager_service_perimeter_dry_run_resource.dry_run_service_perimeter_resource]
 }
 
 resource "google_access_context_manager_service_perimeter_dry_run_egress_policy" "egress_policies" {


### PR DESCRIPTION
This PR contains the addition of a depends_on with the resources that add projects to the perimeter, in the resources that create ingress policies, correcting the error generated by the VPC Service Controls module when it needs to add a project to the perimeter, and create an ingress rule for the same project, at the same time.

Error: Error creating ServicePerimeterIngressPolicy: googleapi: Error 400: Invalid Directional Policies set in Perimeter 'accessPolicies/ACCESS_CONTEXT_MANAGER_ID/servicePerimeters/SERVICE_PERIMETER_NAME': Error in IngressTo: 'projects/PROJECT_NUMBER is defined in `IngressTo.resources`, but it is not present in `ServicePerimeterConfig.resources`. Only resources protected by this Service Perimeter can be put in IngressTo.resources.

With the addition of this depends_on, the module will always add the project before creating the ingress policy for it.