### PR TITLE
fix!: remove create before destroy lifecycle rule from service perimeter policy resources

### DIFF
--- a/modules/regular_service_perimeter/vpc-sc-policies.tf
+++ b/modules/regular_service_perimeter/vpc-sc-policies.tf
@@ -87,9 +87,6 @@ resource "google_access_context_manager_service_perimeter_ingress_policy" "ingre
       }
     }
   }
-  lifecycle {
-    create_before_destroy = true
-  }
 
   depends_on = [google_access_context_manager_service_perimeter_resource.service_perimeter_resource]
 }
@@ -134,9 +131,6 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
         }
       }
     }
-  }
-  lifecycle {
-    create_before_destroy = true
   }
 }
 
@@ -183,9 +177,6 @@ resource "google_access_context_manager_service_perimeter_dry_run_ingress_policy
       }
     }
   }
-  lifecycle {
-    create_before_destroy = true
-  }
 
   depends_on = [google_access_context_manager_service_perimeter_dry_run_resource.dry_run_service_perimeter_resource]
 }
@@ -230,8 +221,5 @@ resource "google_access_context_manager_service_perimeter_dry_run_egress_policy"
         }
       }
     }
-  }
-  lifecycle {
-    create_before_destroy = true
   }
 }


### PR DESCRIPTION
The ingress and egress policy resources managed here force replacement on any changes to their rules but it is not permitted to have multiple policies with the same title attached to a service perimeter.
Therefore it is not possible to create replacement policies before destroying existing policies.

Fixes #225