### PR TITLE
feat: configurable lifecycle.create_before_destroy for service perimeter policies

### DIFF
--- a/modules/regular_service_perimeter/variables.tf
+++ b/modules/regular_service_perimeter/variables.tf
@@ -30,7 +30,7 @@ variable "perimeter_name" {
 }
 
 variable "restricted_services" {
-  description = "GCP services that are subject to the Service Perimeter restrictions. Must contain a list of services. For example, if storage.googleapis.com is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions."
+  description = "GCP services that are subject to the Service Perimeter restrictions. Must contain a list of services. For example, if storage.googleapis.com is specified, access to the storage bu[...]"
   type        = list(string)
   default     = []
 }
@@ -42,19 +42,19 @@ variable "resources" {
 }
 
 variable "resource_keys" {
-  description = "A list of keys to use for the Terraform state. The order should correspond to var.resources and the keys must not be dynamically computed. If `null`, var.resources will be used as keys."
+  description = "A list of keys to use for the Terraform state. The order should correspond to var.resources and the keys must not be dynamically computed. If `null`, var.resources will be used as[...]"
   type        = list(string)
   default     = null
 }
 
 variable "access_levels" {
-  description = "A list of AccessLevel resource names that allow resources within the ServicePerimeter to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel is a syntax error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via GCP calls with request origins within the perimeter. Example: 'accessPolicies/MY_POLICY/accessLevels/MY_LEVEL'. For Service Perimeter Bridge, must be empty."
+  description = "A list of AccessLevel resource names that allow resources within the ServicePerimeter to be accessed from the internet. AccessLevels listed must be in the same policy as this Serv[...]"
   type        = list(string)
   default     = []
 }
 
 variable "restricted_services_dry_run" {
-  description = "(Dry-run) GCP services that are subject to the Service Perimeter restrictions. Must contain a list of services. For example, if storage.googleapis.com is specified, access to the storage buckets inside the perimeter must meet the perimeter's access restrictions.  If set, a dry-run policy will be set."
+  description = "(Dry-run) GCP services that are subject to the Service Perimeter restrictions. Must contain a list of services. For example, if storage.googleapis.com is specified, access to the [...]"
   type        = list(string)
   default     = []
 }
@@ -66,37 +66,37 @@ variable "resources_dry_run" {
 }
 
 variable "resource_keys_dry_run" {
-  description = "(Dry-run) A list of keys to use for the Terraform state. The order should correspond to var.resources_dry_run and the keys must not be dynamically computed. If `null`, var.resources_dry_run will be used as keys."
+  description = "(Dry-run) A list of keys to use for the Terraform state. The order should correspond to var.resources_dry_run and the keys must not be dynamically computed. If `null`, var.resourc[...]"
   type        = list(string)
   default     = null
 }
 
 variable "ingress_policies_keys" {
-  description = "A list of keys to use for the Terraform state. The order should correspond to var.ingress_policies and the keys must not be dynamically computed. If `null`, var.ingress_policies will be used as keys."
+  description = "A list of keys to use for the Terraform state. The order should correspond to var.ingress_policies and the keys must not be dynamically computed. If `null`, var.ingress_policies w[...]"
   type        = list(string)
   default     = null
 }
 
 variable "egress_policies_keys" {
-  description = "A list of keys to use for the Terraform state. The order should correspond to var.egress_policies and the keys must not be dynamically computed. If `null`, var.egress_policies will be used as keys."
+  description = "A list of keys to use for the Terraform state. The order should correspond to var.egress_policies and the keys must not be dynamically computed. If `null`, var.egress_policies wil[...]"
   type        = list(string)
   default     = null
 }
 
 variable "ingress_policies_keys_dry_run" {
-  description = "(Dry-run) A list of keys to use for the Terraform state. The order should correspond to var.ingress_policies_dry_run and the keys must not be dynamically computed. If `null`, var.ingress_policies_dry_run will be used as keys."
+  description = "(Dry-run) A list of keys to use for the Terraform state. The order should correspond to var.ingress_policies_dry_run and the keys must not be dynamically computed. If `null`, var.[...]"
   type        = list(string)
   default     = null
 }
 
 variable "egress_policies_keys_dry_run" {
-  description = "(Dry-run) A list of keys to use for the Terraform state. The order should correspond to var.egress_policies_dry_run and the keys must not be dynamically computed. If `null`, var.egress_policies_dry_run will be used as keys."
+  description = "(Dry-run) A list of keys to use for the Terraform state. The order should correspond to var.egress_policies_dry_run and the keys must not be dynamically computed. If `null`, var.e[...]"
   type        = list(string)
   default     = null
 }
 
 variable "access_levels_dry_run" {
-  description = "(Dry-run) A list of AccessLevel resource names that allow resources within the ServicePerimeter to be accessed from the internet. AccessLevels listed must be in the same policy as this ServicePerimeter. Referencing a nonexistent AccessLevel is a syntax error. If no AccessLevel names are listed, resources within the perimeter can only be accessed via GCP calls with request origins within the perimeter. Example: 'accessPolicies/MY_POLICY/accessLevels/MY_LEVEL'. For Service Perimeter Bridge, must be empty. If set, a dry-run policy will be set."
+  description = "(Dry-run) A list of AccessLevel resource names that allow resources within the ServicePerimeter to be accessed from the internet. AccessLevels listed must be in the same policy as[...]"
   type        = list(string)
   default     = []
 }
@@ -108,7 +108,7 @@ variable "shared_resources" {
 }
 
 variable "egress_policies" {
-  description = "A list of all [egress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#egress-rules-reference), each list object has a `from` and `to` value that describes egress_from and egress_to.\n\nExample: `[{ from={ identities=[], identity_type=\"ID_TYPE\" }, to={ resources=[], operations={ \"SRV_NAME\"={ OP_TYPE=[] }}}}]`\n\nValid Values:\n`ID_TYPE` = `null` or `IDENTITY_TYPE_UNSPECIFIED` (only allow indentities from list); `ANY_IDENTITY`; `ANY_USER_ACCOUNT`; `ANY_SERVICE_ACCOUNT`\n`SRV_NAME` = \"`*`\" (allow all services) or [Specific Services](https://cloud.google.com/vpc-service-controls/docs/supported-products#supported_products)\n`OP_TYPE` = [methods](https://cloud.google.com/vpc-service-controls/docs/supported-method-restrictions) or [permissions](https://cloud.google.com/vpc-service-controls/docs/supported-method-restrictions)"
+  description = "A list of all [egress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#egress-rules-reference), each list object has a `from` and `to` value that[...]"
   type = list(object({
     title = optional(string, null)
     from = object({
@@ -133,7 +133,7 @@ variable "egress_policies" {
 }
 
 variable "ingress_policies" {
-  description = "A list of all [ingress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#ingress-rules-reference), each list object has a `from` and `to` value that describes ingress_from and ingress_to.\n\nExample: `[{ from={ sources={ resources=[], access_levels=[] }, identities=[], identity_type=\"ID_TYPE\" }, to={ resources=[], operations={ \"SRV_NAME\"={ OP_TYPE=[] }}}}]`\n\nValid Values:\n`ID_TYPE` = `null` or `IDENTITY_TYPE_UNSPECIFIED` (only allow indentities from list); `ANY_IDENTITY`; `ANY_USER_ACCOUNT`; `ANY_SERVICE_ACCOUNT`\n`SRV_NAME` = \"`*`\" (allow all services) or [Specific Services](https://cloud.google.com/vpc-service-controls/docs/supported-products#supported_products)\n`OP_TYPE` = [methods](https://cloud.google.com/vpc-service-controls/docs/supported-method-restrictions) or [permissions](https://cloud.google.com/vpc-service-controls/docs/supported-method-restrictions)"
+  description = "A list of all [ingress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#ingress-rules-reference), each list object has a `from` and `to` value th[...]"
   type = list(object({
     title = optional(string, null)
     from = object({
@@ -157,7 +157,7 @@ variable "ingress_policies" {
 }
 
 variable "egress_policies_dry_run" {
-  description = "A list of all [egress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#egress-rules-reference), each list object has a `from` and `to` value that describes egress_from and egress_to. Use same formatting as `egress_policies`."
+  description = "A list of all [egress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#egress-rules-reference), each list object has a `from` and `to` value that[...]"
   type = list(object({
     title = optional(string, null)
     from = object({
@@ -182,7 +182,7 @@ variable "egress_policies_dry_run" {
 }
 
 variable "ingress_policies_dry_run" {
-  description = "A list of all [ingress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#ingress-rules-reference), each list object has a `from` and `to` value that describes ingress_from and ingress_to. Use same formatting as `ingress_policies`."
+  description = "A list of all [ingress policies](https://cloud.google.com/vpc-service-controls/docs/ingress-egress-rules#ingress-rules-reference), each list object has a `from` and `to` value th[...]"
   type = list(object({
     title = optional(string, null)
     from = object({
@@ -206,13 +206,20 @@ variable "ingress_policies_dry_run" {
 }
 
 variable "vpc_accessible_services" {
-  description = "A list of [VPC Accessible Services](https://cloud.google.com/vpc-service-controls/docs/vpc-accessible-services) that will be restricted within the VPC Network. Use [\"*\"] to allow any service (disable VPC Accessible Services); Use [\"RESTRICTED-SERVICES\"] to match the restricted services list; Use [] to not allow any service."
+  description = "A list of [VPC Accessible Services](https://cloud.google.com/vpc-service-controls/docs/vpc-accessible-services) that will be restricted within the VPC Network. Use [\"*\"] to all[...]"
   type        = list(string)
   default     = ["*"]
 }
 
 variable "vpc_accessible_services_dry_run" {
-  description = "(Dry-run) A list of [VPC Accessible Services](https://cloud.google.com/vpc-service-controls/docs/vpc-accessible-services) that will be restricted within the VPC Network. Use [\"*\"] to allow any service (disable VPC Accessible Services); Use [\"RESTRICTED-SERVICES\"] to match the restricted services list; Use [] to not allow any service."
+  description = "(Dry-run) A list of [VPC Accessible Services](https://cloud.google.com/vpc-service-controls/docs/vpc-accessible-services) that will be restricted within the VPC Network. Use [\"*[...]"
   type        = list(string)
   default     = ["*"]
+}
+
+# New variable to control lifecycle.create_before_destroy on policy resources.
+variable "service_perimeter_create_before_destroy" {
+  description = "Whether to set lifecycle.create_before_destroy on service perimeter policy resources. Set to false to avoid create_before_destroy behavior."
+  type        = bool
+  default     = true
 }

--- a/modules/regular_service_perimeter/variables.tf
+++ b/modules/regular_service_perimeter/variables.tf
@@ -118,6 +118,7 @@ variable "egress_policies" {
       }), {}),
       identity_type = optional(string, null)
       identities    = optional(list(string), null)
+      source_restriction = optional(string, null)
     })
     to = object({
       operations = optional(map(object({
@@ -143,6 +144,7 @@ variable "ingress_policies" {
       }), {}),
       identity_type = optional(string, null)
       identities    = optional(list(string), null)
+      source_restriction = optional(string, null)
     })
     to = object({
       operations = optional(map(object({

--- a/modules/regular_service_perimeter/variables.tf
+++ b/modules/regular_service_perimeter/variables.tf
@@ -216,10 +216,3 @@ variable "vpc_accessible_services_dry_run" {
   type        = list(string)
   default     = ["*"]
 }
-
-# New variable to control lifecycle.create_before_destroy on policy resources.
-variable "service_perimeter_create_before_destroy" {
-  description = "Whether to set lifecycle.create_before_destroy on service perimeter policy resources. Set to false to avoid create_before_destroy behavior."
-  type        = bool
-  default     = true
-}

--- a/modules/regular_service_perimeter/vpc-sc-policies.tf
+++ b/modules/regular_service_perimeter/vpc-sc-policies.tf
@@ -111,7 +111,7 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
         access_level = sources.value == "access_level" ? sources.key != "*" ? "accessPolicies/${var.policy}/accessLevels/${sources.key}" : "*" : null
       }
     }
-    source_restriction = each.value["from"]["sources"] != {} ? "SOURCE_RESTRICTION_ENABLED" : null
+    source_restriction = each.value["from"]["source_restriction"] != null ? each.value["from"]["source_restriction"] : each.value["from"]["sources"] != {} ? "SOURCE_RESTRICTION_ENABLED" : null
   }
   egress_to {
     resources          = each.value["to"]["resources"]
@@ -207,7 +207,7 @@ resource "google_access_context_manager_service_perimeter_dry_run_egress_policy"
         access_level = sources.value == "access_level" ? sources.key != "*" ? "accessPolicies/${var.policy}/accessLevels/${sources.key}" : "*" : null
       }
     }
-    source_restriction = each.value["from"]["sources"] != {} ? "SOURCE_RESTRICTION_ENABLED" : null
+    source_restriction = each.value["from"]["source_restriction"] != null ? each.value["from"]["source_restriction"] : each.value["from"]["sources"] != {} ? "SOURCE_RESTRICTION_ENABLED" : null
   }
   egress_to {
     resources          = each.value["to"]["resources"]

--- a/modules/regular_service_perimeter/vpc-sc-policies.tf
+++ b/modules/regular_service_perimeter/vpc-sc-policies.tf
@@ -86,7 +86,7 @@ resource "google_access_context_manager_service_perimeter_ingress_policy" "ingre
     }
   }
   lifecycle {
-    create_before_destroy = var.service_perimeter_create_before_destroy
+    create_before_destroy = false
   }
 
   depends_on = [google_access_context_manager_service_perimeter_resource.service_perimeter_resource]
@@ -134,7 +134,7 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
     }
   }
   lifecycle {
-    create_before_destroy = var.service_perimeter_create_before_destroy
+    create_before_destroy = false
   }
 }
 
@@ -182,7 +182,7 @@ resource "google_access_context_manager_service_perimeter_dry_run_ingress_policy
     }
   }
   lifecycle {
-    create_before_destroy = var.service_perimeter_create_before_destroy
+    create_before_destroy = false
   }
 
   depends_on = [google_access_context_manager_service_perimeter_dry_run_resource.dry_run_service_perimeter_resource]
@@ -230,6 +230,6 @@ resource "google_access_context_manager_service_perimeter_dry_run_egress_policy"
     }
   }
   lifecycle {
-    create_before_destroy = var.service_perimeter_create_before_destroy
+    create_before_destroy = false
   }
 }

--- a/modules/regular_service_perimeter/vpc-sc-policies.tf
+++ b/modules/regular_service_perimeter/vpc-sc-policies.tf
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-
-
 locals {
   # enforced
   # ingress_rules
@@ -88,7 +86,7 @@ resource "google_access_context_manager_service_perimeter_ingress_policy" "ingre
     }
   }
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = var.service_perimeter_create_before_destroy
   }
 
   depends_on = [google_access_context_manager_service_perimeter_resource.service_perimeter_resource]
@@ -136,7 +134,7 @@ resource "google_access_context_manager_service_perimeter_egress_policy" "egress
     }
   }
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = var.service_perimeter_create_before_destroy
   }
 }
 
@@ -184,7 +182,7 @@ resource "google_access_context_manager_service_perimeter_dry_run_ingress_policy
     }
   }
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = var.service_perimeter_create_before_destroy
   }
 
   depends_on = [google_access_context_manager_service_perimeter_dry_run_resource.dry_run_service_perimeter_resource]
@@ -232,6 +230,6 @@ resource "google_access_context_manager_service_perimeter_dry_run_egress_policy"
     }
   }
   lifecycle {
-    create_before_destroy = true
+    create_before_destroy = var.service_perimeter_create_before_destroy
   }
 }


### PR DESCRIPTION
# What

Add variable service_perimeter_create_before_destroy (default true) and use it for lifecycle.create_before_destroy on ingress/egress/dry-run policy resources.

# Why
Allows consumers to set create_before_destroy = false (some environments require this to avoid resource renaming/duplicate state artifacts).

Updating a regular service perimeter threw error:

```
Plan: 1 to add, 0 to change, 1 to destroy.
module.bigquery_protection_perimeter.google_access_context_manager_service_perimeter_ingress_policy.ingress_policies["1"]: Creating...
╷
│ Error: Error creating ServicePerimeterIngressPolicy: googleapi: Error 400: Ingress and Egress rules titles must be unique within a perimeter.
│ 
│   with module.bigquery_protection_perimeter.google_access_context_manager_service_perimeter_ingress_policy.ingress_policies["1"],
│   on .terraform/modules/bigquery_protection_perimeter/modules/regular_service_perimeter/vpc-sc-policies.tf line 51, in resource "google_access_context_manager_service_perimeter_ingress_policy" "ingress_policies":
│   51: resource "google_access_context_manager_service_perimeter_ingress_policy" "ingress_policies" {
│ 

```

# Backwards compatible
`default = true` so behavior is unchanged for existing users.
Usage example showing how to set it to false.

```
module "regular_service_perimeter_1" {
  source = "terraform-google-modules/vpc-service-controls/google//modules/regular_service_perimeter"
  version = "..."

  # other inputs ...
  service_perimeter_create_before_destroy = false
}```