### PR TITLE
fix: add create_before_destroy lifecycle to Access Level resource

### DIFF
--- a/modules/access_level/main.tf
+++ b/modules/access_level/main.tf
@@ -62,4 +62,7 @@ resource "google_access_context_manager_access_level" "access_level" {
 
     combining_function = var.combining_function
   }
+  lifecycle {
+    create_before_destroy = true
+  }
 }


### PR DESCRIPTION
This PR introduces a `lifecycle { create_before_destroy = true }` block to the Access Level resource.

Currently, when transitioning a Service Perimeter (e.g., from dry-run to enforced mode) that requires replacing an Access Level, Terraform attempts to destroy the existing Access Level before creating the new one. Since the perimeter still references the old Access Level during this process, it triggers the following error:

`Error: Error when reading or editing AccessLevel: googleapi: Error 400: Level name <ACCESS_LEVEL_DRY_RUN_ID> is not available in this Access Policy resource, but is referenced in 'spec' field of Perimeter. If you are trying to delete a Level which is referenced in this Perimeter, you must first remove the reference.`

By adding **create_before_destroy = true,** we ensure that Terraform provisions the new Access Level first, updates the Perimeter's references to point to the new resource, and only then destroys the old one.