### PR TITLE
fix(regular_service_perimeter): dry-run-only perimeters never converge — status is emitted unconditionally

### DIFF
--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -145,6 +145,31 @@ steps:
     - verify-scoped-example-access-level-dry-run
   name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
   args: ['/bin/bash', '-c', 'cft test run TestScopedExampleAccessLevelDryRun --stage destroy --verbose']
+
+# dry-run-only perimeter (no enforced configuration)
+- id: init-simple-example-dry-run-only
+  waitFor:
+    - destroy-scoped-example-access-level-dry-run
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExampleDryRunOnly --stage init --verbose']
+
+- id: apply-simple-example-dry-run-only
+  waitFor:
+    - init-simple-example-dry-run-only
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExampleDryRunOnly --stage apply --verbose']
+
+- id: verify-simple-example-dry-run-only
+  waitFor:
+    - apply-simple-example-dry-run-only
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExampleDryRunOnly --stage verify --verbose']
+
+- id: destroy-simple-example-dry-run-only
+  waitFor:
+    - verify-simple-example-dry-run-only
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'cft test run TestSimpleExampleDryRunOnly --stage destroy --verbose']
 tags:
 - 'ci'
 - 'integration'

--- a/examples/simple_example_dry_run_only/README.md
+++ b/examples/simple_example_dry_run_only/README.md
@@ -1,0 +1,36 @@
+# Simple Example with a Dry-run-only Perimeter
+
+This example illustrates how to use the `vpc-service-controls` module to stage a regular
+service perimeter in **dry-run mode only** -- every enforced input is left at its default,
+and configuration is supplied exclusively through the `_dry_run` inputs.
+
+This is the supported way to stage a perimeter and observe its violations before turning
+enforcement on. It is also the only example that leaves the enforced side entirely empty,
+which makes it the regression test for the module emitting an empty `status {}` block
+that the API does not store.
+
+# Requirements
+1. Make sure you've gone through the root [Requirement Section](../../#requirements)
+
+
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| parent\_id | The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent. | `string` | n/a | yes |
+| policy\_name | The policy's name. | `string` | n/a | yes |
+| protected\_project\_number | Project number of the project INSIDE the dry-run service perimeter. | `number` | n/a | yes |
+| scopes | Folder or project on which this policy is applicable. Format: 'folders/FOLDER\_ID' or 'projects/PROJECT\_NUMBER' | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| policy\_id | Resource name of the AccessPolicy. |
+| policy\_name | Name of the AccessPolicy. |
+| protected\_project\_number | Project number of the project INSIDE the dry-run service perimeter |
+| service\_perimeter\_name | Service perimeter name |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/simple_example_dry_run_only/main.tf
+++ b/examples/simple_example_dry_run_only/main.tf
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module "access_context_manager_policy" {
+  source  = "terraform-google-modules/vpc-service-controls/google"
+  version = "~> 8.0"
+
+  parent_id   = var.parent_id
+  policy_name = var.policy_name
+  scopes      = var.scopes
+}
+
+# A perimeter staged in dry-run mode only: every enforced input is left at its
+# default (empty), and configuration is supplied exclusively through the
+# `_dry_run` inputs. This is the supported way to stage a perimeter and observe
+# its violations before turning enforcement on.
+#
+# No existing example covers this shape -- every other one populates the
+# enforced side as well -- which is why the non-convergence it triggers went
+# unnoticed.
+module "regular_service_perimeter_dry_run_only" {
+  source  = "terraform-google-modules/vpc-service-controls/google//modules/regular_service_perimeter"
+  version = "~> 8.0"
+
+  policy         = module.access_context_manager_policy.policy_id
+  perimeter_name = "regular_perimeter_dry_run_only"
+  description    = "Perimeter staged in dry-run mode with no enforced configuration"
+
+  # Enforced side deliberately untouched. `vpc_accessible_services` is left at
+  # its ["*"] default, which means "no restriction" -- so nothing here asks the
+  # module for an enforced configuration.
+
+  resources_dry_run           = [var.protected_project_number]
+  restricted_services_dry_run = ["storage.googleapis.com"]
+}

--- a/examples/simple_example_dry_run_only/outputs.tf
+++ b/examples/simple_example_dry_run_only/outputs.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "policy_id" {
+  description = "Resource name of the AccessPolicy."
+  value       = module.access_context_manager_policy.policy_id
+}
+
+output "policy_name" {
+  description = "Name of the AccessPolicy."
+  value       = var.policy_name
+}
+
+output "protected_project_number" {
+  description = "Project number of the project INSIDE the dry-run service perimeter"
+  value       = var.protected_project_number
+}
+
+output "service_perimeter_name" {
+  description = "Service perimeter name"
+  value       = module.regular_service_perimeter_dry_run_only.perimeter_name
+}

--- a/examples/simple_example_dry_run_only/variables.tf
+++ b/examples/simple_example_dry_run_only/variables.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "parent_id" {
+  description = "The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent."
+  type        = string
+}
+
+variable "policy_name" {
+  description = "The policy's name."
+  type        = string
+}
+
+variable "protected_project_number" {
+  description = "Project number of the project INSIDE the dry-run service perimeter."
+  type        = number
+}
+
+variable "scopes" {
+  description = "Folder or project on which this policy is applicable. Format: 'folders/FOLDER_ID' or 'projects/PROJECT_NUMBER'"
+  type        = list(string)
+  default     = []
+}

--- a/modules/regular_service_perimeter/main.tf
+++ b/modules/regular_service_perimeter/main.tf
@@ -16,6 +16,22 @@
 
 locals {
   dry_run = (length(var.restricted_services_dry_run) > 0 || length(var.resources_dry_run) > 0 || length(var.access_levels_dry_run) > 0 || length(var.egress_policies_dry_run) > 0 || length(var.ingress_policies_dry_run) > 0 || !contains(var.vpc_accessible_services_dry_run, "*"))
+
+  # Mirror of local.dry_run for the enforced side, so that `status` is only
+  # rendered when the caller has actually asked for enforced configuration.
+  #
+  # Without this, a dry-run-only perimeter emits an empty `status {}`. The API
+  # does not store an empty status, so it is absent from every subsequent read
+  # and the resource never converges: `terraform plan` reports `+ status {}`
+  # immediately after a clean apply, forever.
+  #
+  # The first three inputs are the ones the `status` block below actually
+  # carries. `resources` and the ingress/egress policies are managed by their
+  # own resources rather than by this block, but they are included here
+  # deliberately: gating on them too keeps `status` rendering for every
+  # configuration that renders it today except the genuinely-empty one, which
+  # keeps the behaviour change as small as possible.
+  enforced = (length(var.restricted_services) > 0 || length(var.access_levels) > 0 || !contains(var.vpc_accessible_services, "*") || length(var.resources) > 0 || length(var.egress_policies) > 0 || length(var.ingress_policies) > 0 || length(var.egress_policies_map) > 0 || length(var.ingress_policies_map) > 0)
 }
 
 resource "google_access_context_manager_service_perimeter" "regular_service_perimeter" {
@@ -26,20 +42,23 @@ resource "google_access_context_manager_service_perimeter" "regular_service_peri
   title          = var.perimeter_name
   description    = var.description
 
-  status {
-    restricted_services = var.restricted_services
-    access_levels = formatlist(
-      "accessPolicies/${var.policy}/accessLevels/%s",
-      var.access_levels
-    )
+  dynamic "status" {
+    for_each = local.enforced ? ["enforced"] : []
+    content {
+      restricted_services = var.restricted_services
+      access_levels = formatlist(
+        "accessPolicies/${var.policy}/accessLevels/%s",
+        var.access_levels
+      )
 
 
 
-    dynamic "vpc_accessible_services" {
-      for_each = contains(var.vpc_accessible_services, "*") ? [] : [var.vpc_accessible_services]
-      content {
-        enable_restriction = true
-        allowed_services   = vpc_accessible_services.value
+      dynamic "vpc_accessible_services" {
+        for_each = contains(var.vpc_accessible_services, "*") ? [] : [var.vpc_accessible_services]
+        content {
+          enable_restriction = true
+          allowed_services   = vpc_accessible_services.value
+        }
       }
     }
   }

--- a/test/fixtures/simple_example_dry_run_only/main.tf
+++ b/test/fixtures/simple_example_dry_run_only/main.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_string" "suffix" {
+  length  = 6
+  special = false
+  upper   = false
+}
+
+module "example" {
+  source = "../../../examples/simple_example_dry_run_only"
+
+  parent_id   = var.parent_id
+  policy_name = "int_test_vpc_dry_run_only_${random_string.suffix.result}"
+  scopes      = var.scopes
+
+  protected_project_number = var.protected_project_ids["number"]
+}

--- a/test/fixtures/simple_example_dry_run_only/outputs.tf
+++ b/test/fixtures/simple_example_dry_run_only/outputs.tf
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+output "policy_id" {
+  description = "Resource name of the AccessPolicy."
+  value       = module.example.policy_id
+}
+
+output "policy_name" {
+  description = "Name of the parent policy"
+  value       = module.example.policy_name
+}
+
+output "protected_project_number" {
+  description = "Project number of the project INSIDE the dry-run service perimeter"
+  value       = module.example.protected_project_number
+}
+
+output "service_perimeter_name" {
+  description = "Service perimeter name"
+  value       = module.example.service_perimeter_name
+}

--- a/test/fixtures/simple_example_dry_run_only/variables.tf
+++ b/test/fixtures/simple_example_dry_run_only/variables.tf
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "parent_id" {
+  description = "The parent of this AccessPolicy in the Cloud Resource Hierarchy. As of now, only organization are accepted as parent."
+  type        = string
+}
+
+variable "protected_project_ids" {
+  description = "Project id and number of the project INSIDE the dry-run service perimeter. This map variable expects an \"id\" for the project id and \"number\" key for the project number."
+  type        = object({ id = string, number = number })
+}
+
+variable "scopes" {
+  description = "Folder or project on which this policy is applicable. Format: 'folders/FOLDER_ID' or 'projects/PROJECT_NUMBER'"
+  type        = list(string)
+  default     = []
+}

--- a/test/integration/simple_example_dry_run_only/simple_example_dry_run_only_test.go
+++ b/test/integration/simple_example_dry_run_only/simple_example_dry_run_only_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package simple_example_dry_run_only_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/gcloud"
+	"github.com/GoogleCloudPlatform/cloud-foundation-toolkit/infra/blueprint-test/pkg/tft"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	RetryableTransientErrors = map[string]string{
+		// Editing VPC Service Controls is eventually consistent.
+		".*Error 403.*Request is prohibited by organization's policy.*vpcServiceControlsUniqueIdentifier.*": "Request is prohibited by organization's policy.",
+	}
+)
+
+// TestSimpleExampleDryRunOnly covers a perimeter staged in dry-run mode with no
+// enforced configuration at all.
+//
+// Every other example populates the enforced side, so this is the only test that
+// exercises the path where `status` has nothing to carry. The regression it guards
+// against is the module emitting an empty `status {}` regardless: the API does not
+// store an empty status, so it never comes back on a read, and the perimeter never
+// converges -- `terraform plan` reports a diff immediately after a clean apply, on
+// every run.
+func TestSimpleExampleDryRunOnly(t *testing.T) {
+	bpt := tft.NewTFBlueprintTest(t,
+		tft.WithRetryableTerraformErrors(RetryableTransientErrors, 6, 2*time.Minute),
+	)
+
+	bpt.DefineVerify(func(assert *assert.Assertions) {
+		// DefaultVerify plans after apply and asserts the detailed exit code is
+		// neither 1 (error) nor 2 (non-empty diff). This is the assertion that
+		// fails without the fix, with exit code 2.
+		bpt.DefaultVerify(assert)
+
+		policyID := bpt.GetStringOutput("policy_id")
+
+		servicePerimeterLink := fmt.Sprintf("accessPolicies/%s/servicePerimeters/%s", policyID, bpt.GetStringOutput("service_perimeter_name"))
+		servicePerimeter := gcloud.Runf(t, "access-context-manager perimeters describe %s --policy %s", servicePerimeterLink, policyID)
+
+		protectedProjectNumber := bpt.GetStringOutput("protected_project_number")
+
+		assert.True(servicePerimeter.Get("useExplicitDryRunSpec").Bool(), "should use explicit Dry Run spec")
+
+		// Dry-run configuration lives in `spec`.
+		resourcesDryRun := servicePerimeter.Get("spec.resources").Array()
+		assert.Equal(1, len(resourcesDryRun), "should have only one resource protected in Dry-run")
+		assert.Equal(fmt.Sprintf("projects/%s", protectedProjectNumber), resourcesDryRun[0].String(), "project %s should be protected in Dry-run", protectedProjectNumber)
+
+		restrictedServicesDryRun := servicePerimeter.Get("spec.restrictedServices").Array()
+		assert.Equal(1, len(restrictedServicesDryRun), "should have only one service protected in Dry-run")
+		assert.Equal("storage.googleapis.com", restrictedServicesDryRun[0].String(), "service 'storage.googleapis.com' should be protected in Dry-run")
+
+		// The enforced side was never configured, so the API should report no
+		// `status` at all -- not an empty one. This asserts the cause directly,
+		// so a failure here distinguishes "the module sent an empty status" from
+		// the more general "the plan was not empty" reported above.
+		assert.False(servicePerimeter.Get("status").Exists(), "should have no enforced status when only dry-run inputs are supplied")
+	})
+
+	bpt.Test()
+}


### PR DESCRIPTION
## Summary

`modules/regular_service_perimeter` renders its `status` block unconditionally, while
`spec` is correctly wrapped in a `dynamic` gated on `local.dry_run`. For a perimeter used
in **dry-run-only** mode — every enforced input left empty, only the `_dry_run` inputs
supplied — the module still emits an empty `status {}`.

The API does not store an empty `status`, so it never appears in a subsequent read. The
result is a diff that applying does not resolve.

Reproduced end to end with the minimal config below — apply is clean, and the very next
plan is not:

```
$ terraform apply -auto-approve
module...regular_service_perimeter: Creation complete after 3s
Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

$ terraform plan
  ~ resource "google_access_context_manager_service_perimeter" "regular_service_perimeter" {
        # (8 unchanged attributes hidden)

      + status {
        }

        # (1 unchanged block hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The single most telling line is `# (1 unchanged block hidden)` — that is `spec`, on the
same resource, in the same plan. **`spec` converges and `status` does not**, which is the
asymmetry stated as directly as it can be.

## Root cause

The asymmetry is visible in the resource itself. From `regular_service_perimeter/main.tf`
at v8.1.0:

```
line 29:  status {                                    <- always rendered
line 48:  dynamic "spec" {                            <- for_each = local.dry_run ? ["dry-run"] : []
line 68:  use_explicit_dry_run_spec = local.dry_run
```

`local.dry_run` is derived from whether any `_dry_run` input is non-empty. There is no
equivalent for the enforced side, so `status` is emitted whether or not the caller
supplied anything for it.

Confirmed against the API: for a dry-run-only perimeter, a `GET` returns no `status` key
at all —

```
top-level keys: ['description', 'etag', 'name', 'spec', 'title', 'useExplicitDryRunSpec']
```

— so config-has-block / remote-has-nothing produces `+ status {}` on every plan. Applying
sends an empty `status`, the API stores nothing, and the next refresh is back where it
started.

## Reproduction

Self-contained, and it needs **only an existing policy id** — no project, because
`restricted_services_dry_run` alone is enough to make `local.dry_run` true, so the
perimeter holds no resources and cannot collide with the "a project may belong to only one
perimeter" rule.

```hcl
variable "policy_id" {
  type        = string
  description = "Existing Access Context Manager policy id (numeric)."
}

module "perimeter" {
  source = "terraform-google-modules/vpc-service-controls/google//modules/regular_service_perimeter"

  policy         = var.policy_id
  perimeter_name = "repro_dry_run_only"
  description    = "Reproduction: dry-run-only perimeter never converges"

  # Enforced side deliberately untouched -> the module still emits `status {}`.
  # Dry-run side populated -> local.dry_run is true, so `spec` renders and
  # use_explicit_dry_run_spec is set.
  restricted_services_dry_run = ["storage.googleapis.com"]
}
```

```sh
terraform init
terraform apply -var policy_id=<policy id>
terraform plan  -var policy_id=<policy id>   # expected empty; is not
```

Verified against module **v8.1.0** on Terraform 1.15.8 with google provider 7.44.0. The
perimeter used for the run was created and destroyed for the purpose.

Corroborating the mechanism, a `GET` on the created perimeter returns no `status` key at
all:

```
["description","etag","name","spec","title","useExplicitDryRunSpec"]
```

Config has the block, remote has nothing, and no apply makes it appear.

## Proposed fix

Mirror what `spec` already does: gate `status` on whether the enforced side has anything in
it.

```hcl
locals {
  enforced = length(var.restricted_services) > 0 ||
    length(var.resources) > 0 ||
    length(var.access_levels) > 0 ||
    length(var.egress_policies) > 0 ||
    length(var.ingress_policies) > 0 ||
    length(var.egress_policies_map) > 0 ||
    length(var.ingress_policies_map) > 0 ||
    !contains(var.vpc_accessible_services, "*")
}
```

Note the `_map` variants are included deliberately. Omitting them would suppress `status`
for a caller who supplies only `ingress_policies_map` / `egress_policies_map` — which are
the non-deprecated forms, so that would be the common case going forward, not an edge one.

```hcl
  dynamic "status" {
    for_each = local.enforced ? ["enforced"] : []
    content {
      # ... existing status body unchanged ...
    }
  }
```

`lifecycle.ignore_changes` keeps all six entries unchanged. I checked that
`ignore_changes` on `status[0].*` is accepted when the block renders zero instances —
`terraform validate` passes (Terraform 1.15.8, google provider 7.44.0) — the entries simply
have nothing to match while the block is absent, and apply again once it renders.

## Tests

Adds `examples/simple_example_dry_run_only` plus its fixture and integration test, and
wires four steps into `build/int.cloudbuild.yaml`.

The assertion that catches this needs nothing bespoke -- `bpt.DefaultVerify(assert)`
already plans after apply and asserts the detailed exit code is neither 1 nor 2. This bug
produces exit code 2. What was missing was an example that reaches the broken path:
**every existing example populates the enforced side**, so `status` is never empty and the
bug never fires. `scoped_example_access_level_dry_run` sets `resources` and
`restricted_services` alongside its `_dry_run` inputs, which is why its name suggests
coverage it does not give.

The test also asserts the cause directly, so a failure distinguishes the mechanism from a
generic non-empty plan:

```go
assert.False(servicePerimeter.Get("status").Exists(),
    "should have no enforced status when only dry-run inputs are supplied")
```

The example uses a **scoped** policy, so it does not contend for the org's single unscoped
policy and needs no `remove_gcloud_org_accesspolicy` step before it -- it chains directly
off the previous destroy.

### What I verified, and what I did not

Verified locally against the patched module (Terraform 1.15.8, google provider 7.44.0):

- `terraform validate` and `terraform fmt -check` pass, including `ignore_changes` on
  `status[0].*` while the block renders zero instances.
- **Dry-run-only now plans without `status`** -- the `+ status {}` shown above is gone,
  while `spec` and `use_explicit_dry_run_spec = true` are unchanged.
- **Negative controls: `status` still renders** for enforced-only, for both-sides, and for
  `vpc_accessible_services` alone. That last one matters -- it is the
  `!contains(..., "*")` branch that a naive `length()`-only condition would miss.

Not run: the integration test itself, which needs a test org whose access policy the
harness can own. It should fail on current `main` and pass with this change -- one CI
run confirms both.

The repository's own `lint` job does pass locally, run exactly as CI runs it
(`developer-tools:1.25`, `test_lint.sh`, exit code 0): documentation generation,
file headers, shellcheck, flake8, tflint, `terraform fmt` and `terraform validate`.
The example README's Inputs/Outputs tables are the output of `make generate_docs`.

## Behaviour change worth reviewing

This is not purely additive and I would rather flag it than have it found in review.

Today, a caller who empties every enforced input gets an empty `status` **sent**, which
under field-mask semantics **clears** `status` on the remote perimeter. With this change
the module stops managing `status` in that state, so an existing enforced configuration
would be **left alone** rather than cleared.

For the dry-run-only case that motivates this issue the two are indistinguishable, because
there is nothing to clear. For anyone currently relying on "empty the variables to tear
down enforcement", it is a real change in meaning.

If that is unacceptable, the same fix behind an opt-in variable would work equally well
for the reported problem:

```hcl
variable "manage_empty_status" {
  description = "Emit an empty `status` block when no enforced configuration is supplied. Set false to avoid a permanent no-op diff on dry-run-only perimeters."
  type        = bool
  default     = true   # preserves today's behaviour
}
```

Happy to switch to whichever the maintainers prefer — the variable-gated version if
backwards compatibility is the priority, the unconditional mirror if the current behaviour
is considered a bug rather than a contract.

## A possibly related gap, flagged rather than fixed here

While working out the condition above I read `local.dry_run` at v8.1.0:

```hcl
locals {
  dry_run = (length(var.restricted_services_dry_run) > 0 || length(var.resources_dry_run) > 0 || length(var.access_levels_dry_run) > 0 || length(var.egress_policies_dry_run) > 0 || length(var.ingress_policies_dry_run) > 0 || !contains(var.vpc_accessible_services_dry_run, "*"))
}
```

It references the **list** forms only. `ingress_policies_dry_run_map` and
`egress_policies_dry_run_map` do not appear — and the list forms they replace are marked
`[DEPRECATED]` in `variables.tf`.

So a caller who supplies dry-run policies only through the map variables — the form the
module now steers people towards — gets `local.dry_run == false`, therefore no `spec`
block and `use_explicit_dry_run_spec = false`. That is a different and arguably more
serious bug than the one this PR fixes.

I have not reproduced it and I am deliberately not fixing it here: separate change,
separate blast radius. Happy to raise it as its own issue if you would rather keep them
apart.

## Notes

- Reproduced on **v8.1.0**, which is the current head of `main`: the `v8.1.0` tag and the
  branch head are the same commit (`087416b`), so the reproduction is against the shipping
  code and this PR is based on it. Both this bug and the gap flagged above are present
  there. `spec` has been dynamic throughout, which is why the asymmetry reads as an
  oversight rather than a deliberate choice.
- The test added here is the first example that leaves the enforced side empty, which is
  why CI is green on this bug today.
